### PR TITLE
uplift target framework version to netcoreapp3.1

### DIFF
--- a/SmokeTester.Tests/SmokeTester.Tests.csproj
+++ b/SmokeTester.Tests/SmokeTester.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="NUnit" Version="3.10.1" />

--- a/SmokeTester/SmokeTester.csproj
+++ b/SmokeTester/SmokeTester.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <AssemblyName>Forte.SmokeTester</AssemblyName>
     <RootNamespace>Forte.SmokeTester</RootNamespace>
     <LangVersion>7.1</LangVersion>


### PR DESCRIPTION
Uplift since new azure agents can't properly perform smoke tests causing http 400 errors