### PR TITLE
Display only first 10 referrers when reporting errors and warnings.

### DIFF
--- a/SmokeTester/Program.cs
+++ b/SmokeTester/Program.cs
@@ -1,4 +1,4 @@
-﻿using CommandLine;
+using CommandLine;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -88,7 +88,8 @@ namespace Forte.SmokeTester
                 Console.WriteLine("\nCrawl warnings:\n");
                 foreach (var error in observer.Warnings)
                 {
-                    Console.WriteLine($"{error.Status}: {error.Url}\nReferrers:\n  {string.Join("\n  ", result[error.Url].Referrers)}\n");
+                    Console.WriteLine($"{error.Status}: {error.Url}");
+                    WriteReferrers(result, error);
                 }
             }
 
@@ -97,7 +98,8 @@ namespace Forte.SmokeTester
                 Console.WriteLine("\nCrawl errors:\n");
                 foreach (var error in observer.Errors)
                 {
-                    Console.WriteLine($"{error.Exception?.FlattenInnerMessages() ?? error.Status.ToString()}: {error.Url}\nReferrers:\n  {string.Join("\n  ", result[error.Url].Referrers)}\n");
+                    Console.WriteLine($"{error.Exception?.FlattenInnerMessages() ?? error.Status.ToString()}: {error.Url}");
+                    WriteReferrers(result, error);
                 }
             }
 
@@ -110,6 +112,21 @@ namespace Forte.SmokeTester
                     Console.WriteLine($"[{entry.Status}] {uri}: \nReferrers:\n  {string.Join("\n  ", entry.Referrers)}\n");
                 }
             }
+        }
+
+        private static void WriteReferrers(IReadOnlyDictionary<Uri, CrawledUrlProperties> result, CrawlError error)
+        {
+            var referrersCount = result[error.Url].Referrers.Count();
+            if (referrersCount > 10)
+            {
+                Console.WriteLine($"Referrers (showing 10 of {referrersCount}):");
+            }
+            else
+            {
+                Console.WriteLine($"Referrers ({referrersCount}):");
+            }
+
+            Console.WriteLine($"  {string.Join("\n  ", result[error.Url].Referrers.Take(10))}\n");
         }
     }
 }

--- a/SmokeTester/Program.cs
+++ b/SmokeTester/Program.cs
@@ -116,7 +116,9 @@ namespace Forte.SmokeTester
 
         private static void WriteReferrers(IReadOnlyDictionary<Uri, CrawledUrlProperties> result, CrawlError error)
         {
-            var referrersCount = result[error.Url].Referrers.Count();
+            var referrers = result[error.Url].Referrers;
+            var referrersCount = referrers.Count();
+            
             if (referrersCount > 10)
             {
                 Console.WriteLine($"Referrers (showing 10 of {referrersCount}):");
@@ -126,7 +128,7 @@ namespace Forte.SmokeTester
                 Console.WriteLine($"Referrers ({referrersCount}):");
             }
 
-            Console.WriteLine($"  {string.Join("\n  ", result[error.Url].Referrers.Take(10))}\n");
+            Console.WriteLine($"  {string.Join("\n  ", referrers.Take(10))}\n");
         }
     }
 }


### PR DESCRIPTION
When crawling a website, often problematic urls are referenced by many referrers. Listing them all in the crawl report makes reading the report hard and does not provide any value. 
This PR reduces the number of referrers displayed to first 10.