### PR TITLE
Don't fail on empty Content-Type header

### DIFF
--- a/SmokeTester/Extractor/HtmlLinkExtractor.cs
+++ b/SmokeTester/Extractor/HtmlLinkExtractor.cs
@@ -19,7 +19,7 @@ namespace Forte.SmokeTester.Extractor
 
         public async Task<IReadOnlyCollection<Uri>> ExtractLinks(CrawlRequest crawlRequest, HttpContent content)
         {
-            if ("text/html".Equals(content.Headers.ContentType.MediaType, StringComparison.OrdinalIgnoreCase) == false)
+            if ("text/html".Equals(content.Headers.ContentType?.MediaType, StringComparison.OrdinalIgnoreCase) == false)
                 return new Uri[0];
 
             using (var contentStream = await content.ReadAsStreamAsync())

--- a/SmokeTester/Extractor/SiteMapLinkExtractor.cs
+++ b/SmokeTester/Extractor/SiteMapLinkExtractor.cs
@@ -12,7 +12,7 @@ namespace Forte.SmokeTester.Extractor
     {
         public async Task<IReadOnlyCollection<Uri>> ExtractLinks(CrawlRequest crawlRequest, HttpContent content)
         {
-            if ("text/xml".Equals(content.Headers.ContentType.MediaType, StringComparison.OrdinalIgnoreCase) == false)
+            if ("text/xml".Equals(content.Headers.ContentType?.MediaType, StringComparison.OrdinalIgnoreCase) == false)
                 return new Uri[0];
 
 


### PR DESCRIPTION
As suprising as it may be - `Content-Type` is a recommended, but not required HTTP header and could be empty, see - https://httpwg.org/specs/rfc9110.html#field.content-type

EDIT: I was also thinking of maybe adding some option to control this behaviour, so that the smoke test would notify the user about missing content-type, but for now this issue (which is itself triggered by #18) prevents me from running releases with smoke tests, so I didn't look into it.